### PR TITLE
relationship now correctly uses the orders model

### DIFF
--- a/src/Traits/ShopTransactionTrait.php
+++ b/src/Traits/ShopTransactionTrait.php
@@ -24,7 +24,7 @@ trait ShopTransactionTrait
      */
     public function order()
     {
-        return $this->belongsTo(Config::get('shop.order_table'), 'order_id');
+        return $this->belongsTo(Config::get('shop.order'), 'order_id');
     }
 
     /**


### PR DESCRIPTION
- Fixed an issue preventing a transaction from being able to obtain it's parent order
