### PR TITLE
Laravel standards

### DIFF
--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -40,7 +40,7 @@ return [
     | This is the table used by LaravelShop to save cart data to the database.
     |
     */
-    'cart_table' => 'cart',
+    'cart_table' => 'carts',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Traits/ShopCalculationsTrait.php
+++ b/src/Traits/ShopCalculationsTrait.php
@@ -167,7 +167,7 @@ trait ShopCalculationsTrait
             ])
             ->join(
                 Config::get('shop.item_table'),
-                Config::get('shop.item_table') . '.' . ($this->table == Config::get('shop.order_table') ? 'order_id' : $this->table . '_id'),
+                Config::get('shop.item_table') . '.' . ($this->table == Config::get('shop.order_table') ? 'order_id' : str_singular($this->table) . '_id'),
                 '=',
                 $this->table . '.id'
             )


### PR DESCRIPTION
This MR makes cart table name laravel-standard compliant with a plural `carts` table name and a singular foreign key column name.
