### PR TITLE
Totals now show decimal values

### DIFF
--- a/src/LaravelShop.php
+++ b/src/LaravelShop.php
@@ -274,7 +274,7 @@ class LaravelShop
             ],
             [
                 Config::get('shop.currency_symbol'),
-                $value,
+                number_format($value, 2),
                 Config::get('shop.currency')
             ],
             Config::get('shop.display_price_format')


### PR DESCRIPTION
Several calculations use `Shop::format()` and currently none of them that do display `$4.00` they display `$4` because decimal values are not forced.  In this MR `Shop::format()` will always provide a format with 2 decimal values.
